### PR TITLE
Syncing send/receive when piping

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,26 @@ Usage of ./wsd:
   -url string
       WebSocket server address to connect to (default "ws://localhost:1337/ws")
   -version
-      Display version number```
+      Display version number
+```
+
+### Piping
+
+One can piping multiples messages by breaking them with new lines  
+E.g.
+```
+echo 'a
+b' \
+| wsd -url="wss://echo.websocket.org"
+```
+results
+```
+> a
+< a
+> b
+< b
+```
+
 
 ## Why?
 

--- a/main.go
+++ b/main.go
@@ -21,12 +21,14 @@ var (
 	protocol       string
 	displayHelp    bool
 	displayVersion bool
+	isPipe         bool
 	red            = color.New(color.FgRed).SprintFunc()
 	magenta        = color.New(color.FgMagenta).SprintFunc()
 	green          = color.New(color.FgGreen).SprintFunc()
 	yellow         = color.New(color.FgYellow).SprintFunc()
 	cyan           = color.New(color.FgCyan).SprintFunc()
 	wg             sync.WaitGroup
+	wgReceive      sync.WaitGroup
 )
 
 func init() {
@@ -62,6 +64,7 @@ func printErrors(errors <-chan error) {
 			os.Exit(0)
 		} else {
 			fmt.Printf("\rerr %v\n> ", red(err))
+			doneReceive()
 		}
 	}
 }
@@ -69,6 +72,7 @@ func printErrors(errors <-chan error) {
 func printReceivedMessages(in <-chan []byte) {
 	for msg := range in {
 		fmt.Printf("\r< %s\n> ", cyan(string(msg)))
+		doneReceive()
 	}
 }
 
@@ -78,6 +82,12 @@ func outLoop(ws *websocket.Conn, out <-chan []byte, errors chan<- error) {
 		if err != nil {
 			errors <- err
 		}
+	}
+}
+
+func doneReceive() {
+	if isPipe {
+		wgReceive.Done()
 	}
 }
 
@@ -126,11 +136,26 @@ func main() {
 	go printErrors(errors)
 	go outLoop(ws, out, errors)
 
+	fi, err := os.Stdin.Stat()
+	if err != nil {
+		panic(err)
+	}
+	isPipe = fi.Mode()&os.ModeNamedPipe != 0
+
 	scanner := bufio.NewScanner(os.Stdin)
 
 	fmt.Print("> ")
 	for scanner.Scan() {
-		out <- []byte(scanner.Text())
+		text := scanner.Text()
+		if isPipe {
+			fmt.Println(green(text))
+			wgReceive.Add(1)
+		}
+		out <- []byte(text)
+		if isPipe {
+			wgReceive.Wait()
+			continue
+		}
 		fmt.Print("> ")
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"sync"
 
+	"strings"
+
 	"github.com/fatih/color"
 	"golang.org/x/net/websocket"
 )
@@ -23,14 +25,14 @@ var (
 	displayHelp        bool
 	displayVersion     bool
 	insecureSkipVerify bool
-	isPipe         bool
+	isPipe             bool
 	red                = color.New(color.FgRed).SprintFunc()
 	magenta            = color.New(color.FgMagenta).SprintFunc()
 	green              = color.New(color.FgGreen).SprintFunc()
 	yellow             = color.New(color.FgYellow).SprintFunc()
 	cyan               = color.New(color.FgCyan).SprintFunc()
 	wg                 sync.WaitGroup
-	wgReceive      sync.WaitGroup	
+	wgReceive          sync.WaitGroup
 )
 
 func init() {
@@ -165,6 +167,10 @@ func main() {
 	for scanner.Scan() {
 		text := scanner.Text()
 		if isPipe {
+			// Ignoring empty lines
+			if len(strings.Trim(text, "")) == 0 {
+				continue
+			}
 			fmt.Println(green(text))
 			wgReceive.Add(1)
 		}
@@ -176,5 +182,7 @@ func main() {
 		fmt.Print("> ")
 	}
 
-	wg.Wait()
+	if !isPipe {
+		wg.Wait()
+	}
 }


### PR DESCRIPTION
This PR is about syncing send/receive when one is piping `wsd`.
Before this PR the command
```
echo 'a 
b   
c                                    
d                                    
e                                    
f' \
| wsd -url="wss://echo.websocket.org"
```
results
```
> a
> b
> c
> d
> e
> f
< a
< c
< c
< d
< f
< f
```
So messages are being sending asynchronously.  

After this PR the results are these
```
> a
< a
> b
< b
> c
< c
> d
< d
> e
< e
> f
< f
```
Now messages are being sending synchronously (waiting for response before move on).  