### PR TITLE
Increased input buffer size

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Usage of ./wsd:
       origin of WebSocket client (default "http://localhost/")
   -protocol string
       WebSocket subprotocol
+  -userAgent string
+      "User-Agent" header
   -url string
       WebSocket server address to connect to (default "ws://localhost:1337/ws")
   -version

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ var (
 	origin             string
 	url                string
 	protocol           string
+	userAgent 	   string
 	displayHelp        bool
 	displayVersion     bool
 	insecureSkipVerify bool
@@ -35,6 +36,7 @@ func init() {
 	flag.StringVar(&origin, "origin", "http://localhost/", "origin of WebSocket client")
 	flag.StringVar(&url, "url", "ws://localhost:1337/ws", "WebSocket server address to connect to")
 	flag.StringVar(&protocol, "protocol", "", "WebSocket subprotocol")
+	flag.StringVar(&userAgent, "userAgent", "", "User-Agent header")
 	flag.BoolVar(&insecureSkipVerify, "insecureSkipVerify", false, "Skip TLS certificate verification")
 	flag.BoolVar(&displayHelp, "help", false, "Display help information about wsd")
 	flag.BoolVar(&displayVersion, "version", false, "Display version number")
@@ -91,6 +93,9 @@ func dial(url, protocol, origin string) (ws *websocket.Conn, err error) {
 	}
 	if protocol != "" {
 		config.Protocol = []string{protocol}
+	}
+	if userAgent != "" {
+		config.Header.Add("User-Agent", userAgent)
 	}
 	config.TlsConfig = &tls.Config{
 		InsecureSkipVerify: insecureSkipVerify,

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func init() {
 }
 
 func inLoop(ws *websocket.Conn, errors chan<- error, in chan<- []byte) {
-	var msg = make([]byte, 512)
+	var msg = make([]byte, 1024)
 
 	for {
 		var n int

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ var (
 	origin             string
 	url                string
 	protocol           string
-	userAgent 	   string
+	userAgent          string
 	displayHelp        bool
 	displayVersion     bool
 	insecureSkipVerify bool


### PR DESCRIPTION
When testing my app with wsd, I've faced incorrect response display for large messages: part of start of the message have been replaced with the tail of the message.

Found out that the input buffer size is 512 (chars?) and replaced it with value 1024.
After that change, the issue described above has gone.
That's it.