### PR TITLE
Make README.md compatible with github's parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ Usage of ./wsd:
   -url string
       WebSocket server address to connect to (default "ws://localhost:1337/ws")
   -version
-      Display version number```
+      Display version number
+```
 
 ## Why?
 


### PR DESCRIPTION
Github is currently rendering the `Why?` section as though it is part of the code block above it. This fixes that.